### PR TITLE
Use event pipe for logs

### DIFF
--- a/samples/ApplicationHost/Properties/launchSettings.json
+++ b/samples/ApplicationHost/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ApplicationHost": {
       "commandName": "Project",
-      "commandLineArgs": "--port 3745 --appinsights=a0b96859-7b2e-4366-a8c9-ed2c",
+      "commandLineArgs": "--port 3745",
       "launchUrl": "http://127.0.0.1:3745/api/v1/services"
     }
   }

--- a/samples/ApplicationHost/Properties/launchSettings.json
+++ b/samples/ApplicationHost/Properties/launchSettings.json
@@ -2,8 +2,7 @@
   "profiles": {
     "ApplicationHost": {
       "commandName": "Project",
-      "commandLineArgs": "--port 3745",
-      "launchBrowser": true,
+      "commandLineArgs": "--port 3745 --appinsights=a0b96859-7b2e-4366-a8c9-ed2c",
       "launchUrl": "http://127.0.0.1:3745/api/v1/services"
     }
   }

--- a/samples/Worker/Worker.cs
+++ b/samples/Worker/Worker.cs
@@ -37,7 +37,8 @@ namespace Worker
                 var consumer = new EventingBasicConsumer(queue);
                 consumer.Received += (model, ea) =>
                 {
-                    _logger.LogInformation("Dequeued " + Encoding.UTF8.GetString(ea.Body));
+                    // Use the raw log API to avoid formatting the JSON string (since it has {})
+                    _logger.Log(LogLevel.Information, 0, "Dequeued " + Encoding.UTF8.GetString(ea.Body), exception: null, formatter: (m, e) => m);
                 };
 
                 queue.BasicConsume(queue: "orders",

--- a/src/Micronetes.Hosting/Logging/LogObject.cs
+++ b/src/Micronetes.Hosting/Logging/LogObject.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Microsoft.Hosting.Logs
+{
+    internal class LogObject : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        internal static readonly Func<object, Exception, string> Callback = (state, exception) => ((LogObject)state).ToString();
+
+        private readonly string _formattedMessage;
+        private List<KeyValuePair<string, object>> _items = new List<KeyValuePair<string, object>>();
+
+        public LogObject(JsonElement element, string formattedMessage)
+        {
+            foreach (var item in element.EnumerateObject())
+            {
+                switch (item.Value.ValueKind)
+                {
+                    case JsonValueKind.Undefined:
+                        break;
+                    case JsonValueKind.Object:
+                        break;
+                    case JsonValueKind.Array:
+                        break;
+                    case JsonValueKind.String:
+                        _items.Add(new KeyValuePair<string, object>(item.Name, item.Value.GetString()));
+                        break;
+                    case JsonValueKind.Number:
+                        _items.Add(new KeyValuePair<string, object>(item.Name, item.Value.GetInt32()));
+                        break;
+                    case JsonValueKind.False:
+                    case JsonValueKind.True:
+                        _items.Add(new KeyValuePair<string, object>(item.Name, item.Value.GetBoolean()));
+                        break;
+                    case JsonValueKind.Null:
+                        _items.Add(new KeyValuePair<string, object>(item.Name, null));
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            _formattedMessage = formattedMessage;
+        }
+
+        public KeyValuePair<string, object> this[int index] => _items[index];
+
+        public int Count => _items.Count;
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            return _formattedMessage;
+        }
+    }
+}

--- a/src/Micronetes.Hosting/Logging/LogObject.cs
+++ b/src/Micronetes.Hosting/Logging/LogObject.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
 
-namespace Microsoft.Hosting.Logs
+namespace Microsoft.Hosting.Logging
 {
     internal class LogObject : IReadOnlyList<KeyValuePair<string, object>>
     {

--- a/src/Micronetes.Hosting/Logging/LogValuesFormatter.cs
+++ b/src/Micronetes.Hosting/Logging/LogValuesFormatter.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Formatter to convert the named format items like {NamedformatItem} to <see cref="M:string.Format"/> format.
+    /// </summary>
+    internal class LogValuesFormatter
+    {
+        private const string NullValue = "(null)";
+        private static readonly object[] EmptyArray = new object[0];
+        private static readonly char[] FormatDelimiters = { ',', ':' };
+        private readonly string _format;
+        private readonly List<string> _valueNames = new List<string>();
+
+        public LogValuesFormatter(string format)
+        {
+            OriginalFormat = format;
+
+            var sb = new StringBuilder();
+            var scanIndex = 0;
+            var endIndex = format.Length;
+
+            while (scanIndex < endIndex)
+            {
+                var openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
+                var closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
+
+                if (closeBraceIndex == endIndex)
+                {
+                    sb.Append(format, scanIndex, endIndex - scanIndex);
+                    scanIndex = endIndex;
+                }
+                else
+                {
+                    // Format item syntax : { index[,alignment][ :formatString] }.
+                    var formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
+
+                    sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
+                    sb.Append(_valueNames.Count.ToString(CultureInfo.InvariantCulture));
+                    _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+                    sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+
+                    scanIndex = closeBraceIndex + 1;
+                }
+            }
+
+            _format = sb.ToString();
+        }
+
+        public string OriginalFormat { get; private set; }
+        public List<string> ValueNames => _valueNames;
+
+        private static int FindBraceIndex(string format, char brace, int startIndex, int endIndex)
+        {
+            // Example: {{prefix{{{Argument}}}suffix}}.
+            var braceIndex = endIndex;
+            var scanIndex = startIndex;
+            var braceOccurenceCount = 0;
+
+            while (scanIndex < endIndex)
+            {
+                if (braceOccurenceCount > 0 && format[scanIndex] != brace)
+                {
+                    if (braceOccurenceCount % 2 == 0)
+                    {
+                        // Even number of '{' or '}' found. Proceed search with next occurence of '{' or '}'.
+                        braceOccurenceCount = 0;
+                        braceIndex = endIndex;
+                    }
+                    else
+                    {
+                        // An unescaped '{' or '}' found.
+                        break;
+                    }
+                }
+                else if (format[scanIndex] == brace)
+                {
+                    if (brace == '}')
+                    {
+                        if (braceOccurenceCount == 0)
+                        {
+                            // For '}' pick the first occurence.
+                            braceIndex = scanIndex;
+                        }
+                    }
+                    else
+                    {
+                        // For '{' pick the last occurence.
+                        braceIndex = scanIndex;
+                    }
+
+                    braceOccurenceCount++;
+                }
+
+                scanIndex++;
+            }
+
+            return braceIndex;
+        }
+
+        private static int FindIndexOfAny(string format, char[] chars, int startIndex, int endIndex)
+        {
+            var findIndex = format.IndexOfAny(chars, startIndex, endIndex - startIndex);
+            return findIndex == -1 ? endIndex : findIndex;
+        }
+
+        public string Format(object[] values)
+        {
+            if (values != null)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    values[i] = FormatArgument(values[i]);
+                }
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, _format, values ?? EmptyArray);
+        }
+
+        internal string Format()
+        {
+            return _format;
+        }
+
+        internal string Format(object arg0)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0));
+        }
+
+        internal string Format(object arg0, object arg1)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1));
+        }
+
+        internal string Format(object arg0, object arg1, object arg2)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1), FormatArgument(arg2));
+        }
+
+        public KeyValuePair<string, object> GetValue(object[] values, int index)
+        {
+            if (index < 0 || index > _valueNames.Count)
+            {
+                throw new IndexOutOfRangeException(nameof(index));
+            }
+
+            if (_valueNames.Count > index)
+            {
+                return new KeyValuePair<string, object>(_valueNames[index], values[index]);
+            }
+
+            return new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetValues(object[] values)
+        {
+            var valueArray = new KeyValuePair<string, object>[values.Length + 1];
+            for (var index = 0; index != _valueNames.Count; ++index)
+            {
+                valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
+            }
+
+            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
+            return valueArray;
+        }
+
+        private object FormatArgument(object value)
+        {
+            if (value == null)
+            {
+                return NullValue;
+            }
+
+            // since 'string' implements IEnumerable, special case it
+            if (value is string)
+            {
+                return value;
+            }
+
+            // if the value implements IEnumerable, build a comma separated string.
+            var enumerable = value as IEnumerable;
+            if (enumerable != null)
+            {
+                return string.Join(", ", enumerable.Cast<object>().Select(o => o ?? NullValue));
+            }
+
+            return value;
+        }
+
+    }
+}

--- a/src/Micronetes.Hosting/Logging/LoggerException.cs
+++ b/src/Micronetes.Hosting/Logging/LoggerException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections;
+using System.Runtime.Serialization;
+using System.Text.Json;
+
+namespace Micronetes.Hosting.Logging
+{
+    internal class LoggerException : Exception
+    {
+        private readonly JsonElement _exceptionMessage;
+
+        public LoggerException(JsonElement exceptionMessage)
+        {
+            _exceptionMessage = exceptionMessage;
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("ClassName", _exceptionMessage.GetProperty("TypeName").GetString(), typeof(string)); // Do not rename (binary serialization)
+            info.AddValue("Message", Message, typeof(string)); // Do not rename (binary serialization)
+            info.AddValue("Data", Data, typeof(IDictionary)); // Do not rename (binary serialization)
+            info.AddValue("InnerException", null, typeof(Exception)); // Do not rename (binary serialization)
+            info.AddValue("HelpURL", null, typeof(string)); // Do not rename (binary serialization)
+            info.AddValue("StackTraceString", StackTrace, typeof(string)); // Do not rename (binary serialization)
+            info.AddValue("RemoteStackTraceString", StackTrace, typeof(string)); // Do not rename (binary serialization)
+            info.AddValue("RemoteStackIndex", 0, typeof(int)); // Do not rename (binary serialization)
+            info.AddValue("ExceptionMethod", null, typeof(string)); // Do not rename (binary serialization)
+            info.AddValue("HResult", int.Parse(_exceptionMessage.GetProperty("HResult").GetString())); // Do not rename (binary serialization)
+            info.AddValue("Source", Source, typeof(string)); // Do not rename (binary serialization
+            info.AddValue("WatsonBuckets", null, typeof(byte[])); // Do not rename (binary serialization)
+        }
+
+        public override string Message => _exceptionMessage.GetProperty("Message").GetString();
+
+        public override string StackTrace => _exceptionMessage.GetProperty("VerboseMessage").GetString();
+
+        public override string ToString()
+        {
+            return _exceptionMessage.GetProperty("VerboseMessage").GetString();
+        }
+    }
+}

--- a/src/Micronetes.Hosting/Micronetes.Hosting.csproj
+++ b/src/Micronetes.Hosting/Micronetes.Hosting.csproj
@@ -9,10 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.0.1" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />

--- a/src/Micronetes.Hosting/MicronetesHost.cs
+++ b/src/Micronetes.Hosting/MicronetesHost.cs
@@ -347,8 +347,6 @@ namespace Micronetes.Hosting
                                             .MinimumLevel.Verbose()
                                             .Enrich.FromLogContext();
 
-                loggerConfiguration.WriteTo.Console();
-
                 var elasticSearch = configuration["elastic"];
 
                 if (!string.IsNullOrEmpty(elasticSearch))

--- a/src/Micronetes.Hosting/Model/Application.cs
+++ b/src/Micronetes.Hosting/Model/Application.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -104,6 +105,8 @@ namespace Micronetes.Hosting.Model
         }
 
         public Dictionary<string, Service> Services { get; }
+
+        internal ILoggerFactory LoggerFactory { get; set; }
 
         internal void PopulateEnvironment(Service service, Action<string, string> set)
         {

--- a/src/Micronetes/Micronetes.csproj
+++ b/src/Micronetes/Micronetes.csproj
@@ -11,9 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.26.0" />
     <PackageReference Include="protobuf-net.Grpc" Version="1.0.21" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.0.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
     <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.100" />

--- a/src/Micronetes/MicronetesServiceCollectionExtensions.cs
+++ b/src/Micronetes/MicronetesServiceCollectionExtensions.cs
@@ -6,8 +6,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Trace.Configuration;
 using RabbitMQ.Client;
-using Serilog;
-using Serilog.Events;
 using StackExchange.Redis;
 
 namespace Micronetes
@@ -16,22 +14,7 @@ namespace Micronetes
     {
         public static IHostBuilder UseMicronetes(this IHostBuilder builder)
         {
-            return builder.ConfigureServices(services => services.AddMicronetes())
-                          .UseSerilog((context, config) =>
-                          {
-                              config.MinimumLevel.Debug()
-                              .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                              .Enrich.FromLogContext()
-                              .Enrich.WithProperty("Application", context.HostingEnvironment.ApplicationName)
-                              .Enrich.WithProperty("Instance", context.Configuration["APP_INSTANCE"])
-                              .WriteTo.Console();
-
-                              var elasticSearchUrl = context.Configuration.GetUrl("elk:elastic") ?? context.Configuration.GetUrl("elastic");
-                              if (!string.IsNullOrEmpty(elasticSearchUrl))
-                              {
-                                  config.WriteTo.Elasticsearch(elasticSearchUrl);
-                              }
-                          });
+            return builder.ConfigureServices(services => services.AddMicronetes());
         }
 
         private static IServiceCollection AddMicronetes(this IServiceCollection services)

--- a/src/dotnet-micronetes/Program.cs
+++ b/src/dotnet-micronetes/Program.cs
@@ -86,14 +86,28 @@ namespace Micronetes.Host
 
             command.AddOption(new Option("--port")
             {
-                Description = "Port to run the run control plane on",
+                Description = "The port to run the run control plane on.",
                 Argument = new Argument<int>("port"),
                 Required = false
             });
-            
+
+            command.AddOption(new Option("--elastic")
+            {
+                Description = "Elasticsearch URL. Write structured application logs to Elasticsearch.",
+                Argument = new Argument<string>("elastic"),
+                Required = false
+            });
+
+            command.AddOption(new Option("--appinsights")
+            {
+                Description = "ApplicationInsights instrumentation key. Write structured application logs to ApplicationInsights.",
+                Argument = new Argument<string>("instrumenation-key"),
+                Required = false
+            });
 
             command.AddOption(new Option("--debug")
             {
+                Description = "Wait for debugger attach in all services.",
                 Required = false
             });
 


### PR DESCRIPTION
- Added remote logging support using event pipe. This will collect logs from Microsoft.Extensions.Logging and push it to the micronetes host. The host can be run with 2 logger providers, elastic search and app insights (more to come) which can be configured via flags.
- Remove Serilog and elastic search sink from the Micronetes SDK.