### PR TITLE
Invoke stderr logs also on outputDataReceived action

### DIFF
--- a/src/Micronetes.Hosting/Infrastructure/ProcessUtil.cs
+++ b/src/Micronetes.Hosting/Infrastructure/ProcessUtil.cs
@@ -72,7 +72,14 @@ namespace Micronetes.Hosting
                 {
                     if (e.Data != null)
                     {
-                        errorBuilder.AppendLine(e.Data);
+                        if (outputDataReceived != null)
+                        {
+                            outputDataReceived.Invoke(e.Data);
+                        }
+                        else
+                        {
+                            errorBuilder.AppendLine(e.Data);
+                        }
                     }
                 };
 


### PR DESCRIPTION
Logs written to stderr are currently not displayed in dashboard-/api-logs. This is a problem for those applications, which write their exceptions and/or error-/fatal-loglevels to stderr.