### PR TITLE
Add a CORS policy to MicronetesHost 

### DIFF
--- a/src/Micronetes.Hosting/Micronetes.Hosting.csproj
+++ b/src/Micronetes.Hosting/Micronetes.Hosting.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Sln" Version="0.3.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>

--- a/src/Micronetes.Hosting/Micronetes.Hosting.csproj
+++ b/src/Micronetes.Hosting/Micronetes.Hosting.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Sln" Version="0.3.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>

--- a/src/Micronetes.Hosting/MicronetesHost.cs
+++ b/src/Micronetes.Hosting/MicronetesHost.cs
@@ -43,6 +43,20 @@ namespace Micronetes.Hosting
 
             builder.Services.AddSingleton(application);
 
+            builder.Services.AddCors(
+                options =>
+                    {
+                        options.AddPolicy(
+                            "default",
+                            policy =>
+                                {
+                                    policy
+                                        .AllowAnyOrigin()
+                                        .AllowAnyHeader()
+                                        .AllowAnyMethod();
+                                });
+                    });
+
             using var app = builder.Build();
 
             var port = app.Configuration["port"] ?? "0";
@@ -50,6 +64,8 @@ namespace Micronetes.Hosting
             app.Listen($"http://127.0.0.1:{port}");
 
             app.UseDeveloperExceptionPage();
+
+            app.UseCors("default");
 
             app.UseStaticFiles();
 


### PR DESCRIPTION
Add a CORS policy to MicronetesHost to allow discover backend service endpoints from a web frontend like a blazor webassembly or any javascript single page application.

In [Blorc.Core](https://github.com/WildGums/Blorc.Core) we have a configuration service that read values from configuration files that could be hosted in the web server.

![image](https://user-images.githubusercontent.com/1785664/76171730-eed85400-6164-11ea-8ca8-7852e9f0cb0c.png)

_micronetes.development.json_

    {
      "Url": "http://127.0.0.1:8001"
    }

We can specify the environment file with a parameter in the Url. In this case `http://localhost:5005?env=development` 

![image](https://user-images.githubusercontent.com/1785664/76171747-221ae300-6165-11ea-96a7-c8658dd8d97e.png)

So, the Program entry point could look like this: 

            var builder = WebAssemblyHostBuilder.CreateDefault(args);
            builder.RootComponents.Add<App>("app");

            builder.Services.AddBlorcCore();
            if (await builder.IsMicronetesConfigurationAvailable())
            {
                builder.Services.AddSingleton<IServiceDiscovery, MicronetesServiceDiscovery>();
            }

where could be possible use an implementation of IServiceDiscovery for Micronetes, to help connect client side with server side when the APIs are hosted in Micronetes. The MicronetesServiceDiscovery is a work in progress and should be available soon as part of Blorc.Core (or as isolate package). 

I use this approach for apps hosted in DCOS (Marathon) with a MarathonServiceDiscovery. But now is possible deploy and debug distributed service locally with Micronetes, so query the available endpoints from the client apps for development purpose could be a good idea.  